### PR TITLE
Added retry for rkv actions

### DIFF
--- a/db/rkv/db.go
+++ b/db/rkv/db.go
@@ -8,9 +8,15 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/ycsb"
+)
+
+const (
+	RetryCount    int           = 3
+	RetryInterval time.Duration = 10 * time.Millisecond
 )
 
 type rkv struct {
@@ -34,11 +40,20 @@ func (r *rkv) CleanupThread(_ context.Context) {
 
 func (r *rkv) Read(ctx context.Context, table string, key string, fields []string) (map[string][]byte, error) {
 	data := make(map[string][]byte, len(fields))
-	resp, err := http.Get(fmt.Sprintf("http://%s/kv?key=%s", rkvAddrDefault, key))
+
+	// Get Request
+	var err error
+	var resp *http.Response
+	for i := 0; err != nil && i < RetryCount; i++ {
+		time.Sleep(RetryInterval << i)
+		resp, err = http.Get(fmt.Sprintf("http://%s/kv?key=%s", rkvAddrDefault, key))
+	}
+
 	if err != nil {
 		fmt.Printf("key is %s and error is %v\n", key, err)
 		return nil, err
 	}
+
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
 		return nil, errors.New("unexpected status code")
@@ -68,11 +83,17 @@ func (r *rkv) Update(ctx context.Context, table string, key string, values map[s
 		return err
 	}
 
-	// Fetch Request
-	resp, err := client.Do(req)
+	// Update Request
+	var resp *http.Response
+	for i := 0; err != nil && i < RetryCount; i++ {
+		time.Sleep(RetryInterval << i)
+		resp, err = client.Do(req)
+	}
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
+
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		return errors.New("unexpected status code")
@@ -108,11 +129,17 @@ func (r *rkv) Insert(ctx context.Context, table string, key string, values map[s
 		return err
 	}
 
-	// Fetch Request
-	resp, err := client.Do(req)
+	// Insert Request
+	var resp *http.Response
+	for i := 0; err != nil && i < RetryCount; i++ {
+		time.Sleep(RetryInterval << i)
+		resp, err = client.Do(req)
+	}
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
@@ -144,11 +171,17 @@ func (r *rkv) Delete(ctx context.Context, table string, key string) error {
 		return err
 	}
 
-	// Fetch Request
-	resp, err := client.Do(req)
+	// Delete Request
+	var resp *http.Response
+	for i := 0; err != nil && i < RetryCount; i++ {
+		time.Sleep(RetryInterval << i)
+		resp, err = client.Do(req)
+	}
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
+
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
 		return errors.New("unexpected status code")

--- a/db/rkv/db.go
+++ b/db/rkv/db.go
@@ -43,7 +43,7 @@ func (r *rkv) Read(ctx context.Context, table string, key string, fields []strin
 
 	// Get Request
 	var err error
-	var resp *http.Response
+	resp, err := http.Get(fmt.Sprintf("http://%s/kv?key=%s", rkvAddrDefault, key))
 	for i := 0; err != nil && i < RetryCount; i++ {
 		time.Sleep(RetryInterval << i)
 		resp, err = http.Get(fmt.Sprintf("http://%s/kv?key=%s", rkvAddrDefault, key))
@@ -84,7 +84,7 @@ func (r *rkv) Update(ctx context.Context, table string, key string, values map[s
 	}
 
 	// Update Request
-	var resp *http.Response
+	resp, err := client.Do(req)
 	for i := 0; err != nil && i < RetryCount; i++ {
 		time.Sleep(RetryInterval << i)
 		resp, err = client.Do(req)
@@ -130,7 +130,7 @@ func (r *rkv) Insert(ctx context.Context, table string, key string, values map[s
 	}
 
 	// Insert Request
-	var resp *http.Response
+	resp, err := client.Do(req)
 	for i := 0; err != nil && i < RetryCount; i++ {
 		time.Sleep(RetryInterval << i)
 		resp, err = client.Do(req)
@@ -172,7 +172,7 @@ func (r *rkv) Delete(ctx context.Context, table string, key string) error {
 	}
 
 	// Delete Request
-	var resp *http.Response
+	resp, err := client.Do(req)
 	for i := 0; err != nil && i < RetryCount; i++ {
 		time.Sleep(RetryInterval << i)
 		resp, err = client.Do(req)


### PR DESCRIPTION
There are transient errors using ycsb to test rkv. Therefore, add 3 more time retries for each request.